### PR TITLE
Default date safeguard in readers

### DIFF
--- a/turn_by_turn/__init__.py
+++ b/turn_by_turn/__init__.py
@@ -5,7 +5,7 @@ from .structures import TbtData, TransverseData
 __title__ = "turn_by_turn"
 __description__ = "Read and write turn-by-turn measurement files from different particle accelerator formats."
 __url__ = "https://github.com/pylhc/turn_by_turn"
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/turn_by_turn/iota.py
+++ b/turn_by_turn/iota.py
@@ -43,7 +43,7 @@ def read_tbt(file_path: Union[str, Path], hdf5_version: int = 2) -> TbtData:
     LOGGER.debug(f"Reading Iota file at path: '{file_path.absolute()}'")
     hdf_file = h5py.File(file_path, "r")
     bunch_ids = [1]
-    date = datetime.now()
+    date = datetime.today().replace(tzinfo=tz.tzutc())  # default here in case file has no time
 
     bpm_names = FUNCTIONS[hdf5_version]["get_bpm_names"](hdf_file)
     nturns = FUNCTIONS[hdf5_version]["get_nturns"](hdf_file, hdf5_version)
@@ -61,7 +61,7 @@ def read_tbt(file_path: Union[str, Path], hdf5_version: int = 2) -> TbtData:
             ),
         )
     ]
-    return TbtData(matrices, date, bunch_ids, nturns)
+    return TbtData(matrices=matrices, date=date, bunch_ids=bunch_ids, nturns=nturns)
 
 
 def _get_turn_by_turn_data_v1(hdf5_v1_file: h5py.File, plane: str, version: int) -> np.ndarray:

--- a/turn_by_turn/iota.py
+++ b/turn_by_turn/iota.py
@@ -6,7 +6,6 @@ Data handling for turn-by-turn measurement files from ``Iota`` (files in **hdf5*
 """
 import logging
 from datetime import datetime
-from dateutil import tz
 from pathlib import Path
 from typing import Callable, Dict, Union
 
@@ -44,7 +43,6 @@ def read_tbt(file_path: Union[str, Path], hdf5_version: int = 2) -> TbtData:
     LOGGER.debug(f"Reading Iota file at path: '{file_path.absolute()}'")
     hdf_file = h5py.File(file_path, "r")
     bunch_ids = [1]
-    date = datetime.today().replace(tzinfo=tz.tzutc())  # default here in case file has no time
 
     bpm_names = FUNCTIONS[hdf5_version]["get_bpm_names"](hdf_file)
     nturns = FUNCTIONS[hdf5_version]["get_nturns"](hdf_file, hdf5_version)
@@ -62,7 +60,7 @@ def read_tbt(file_path: Union[str, Path], hdf5_version: int = 2) -> TbtData:
             ),
         )
     ]
-    return TbtData(matrices=matrices, date=date, bunch_ids=bunch_ids, nturns=nturns)
+    return TbtData(matrices=matrices, bunch_ids=bunch_ids, nturns=nturns)
 
 
 def _get_turn_by_turn_data_v1(hdf5_v1_file: h5py.File, plane: str, version: int) -> np.ndarray:

--- a/turn_by_turn/iota.py
+++ b/turn_by_turn/iota.py
@@ -6,6 +6,7 @@ Data handling for turn-by-turn measurement files from ``Iota`` (files in **hdf5*
 """
 import logging
 from datetime import datetime
+from dateutil import tz
 from pathlib import Path
 from typing import Callable, Dict, Union
 

--- a/turn_by_turn/iota.py
+++ b/turn_by_turn/iota.py
@@ -6,7 +6,6 @@ Data handling for turn-by-turn measurement files from ``Iota`` (files in **hdf5*
 """
 import logging
 from datetime import datetime
-from dateutil import tz
 from pathlib import Path
 from typing import Callable, Dict, Union
 

--- a/turn_by_turn/lhc.py
+++ b/turn_by_turn/lhc.py
@@ -112,7 +112,7 @@ def _read_ascii(file_path: Union[str, Path]) -> Tuple[List[TransverseData], Opti
     data_lines = Path(file_path).read_text().splitlines()
     bpm_names = {"X": [], "Y": []}
     bpm_data = {"X": [], "Y": []}
-    date = datetime.today().replace(tzinfo=tz.tzutc())  # default here in case file has no time
+    date = datetime.today().replace(tzinfo=tz.tzutc())  # default here in case file has no time line
 
     for line in data_lines:
         line = line.strip()

--- a/turn_by_turn/lhc.py
+++ b/turn_by_turn/lhc.py
@@ -167,5 +167,5 @@ def _parse_date(line: str) -> datetime:
     try:
         return datetime.strptime(date_str, _ACQ_DATE_FORMAT)
     except ValueError:
-        LOGGER.warning("No date found in file, defaulting to today")
+        LOGGER.error("Could not parse date in file, defaulting to: Today, UTC")
         return datetime.today().replace(tzinfo=tz.tzutc())

--- a/turn_by_turn/lhc.py
+++ b/turn_by_turn/lhc.py
@@ -112,14 +112,14 @@ def _read_ascii(file_path: Union[str, Path]) -> Tuple[List[TransverseData], Opti
     data_lines = Path(file_path).read_text().splitlines()
     bpm_names = {"X": [], "Y": []}
     bpm_data = {"X": [], "Y": []}
-    date = datetime.today().replace(tzinfo=tz.tzutc())  # default here in case file has no time line
+    date = None  # will switch to TbtData.date's default if not found in file
 
     for line in data_lines:
         line = line.strip()
 
         if _ACQ_DATE_PREFIX in line:
             LOGGER.debug("Acquiring date from file")
-            date = _parse_date(line)  # does not trigger if there is no time in the file!
+            date = _parse_date(line)
             continue
 
         elif line == "" or line.startswith(_ASCII_COMMENT):  # empty or comment line

--- a/turn_by_turn/lhc.py
+++ b/turn_by_turn/lhc.py
@@ -112,14 +112,14 @@ def _read_ascii(file_path: Union[str, Path]) -> Tuple[List[TransverseData], Opti
     data_lines = Path(file_path).read_text().splitlines()
     bpm_names = {"X": [], "Y": []}
     bpm_data = {"X": [], "Y": []}
-    date = None
+    date = datetime.today().replace(tzinfo=tz.tzutc())  # default here in case file has no time
 
     for line in data_lines:
         line = line.strip()
 
         if _ACQ_DATE_PREFIX in line:
             LOGGER.debug("Acquiring date from file")
-            date = _parse_date(line)
+            date = _parse_date(line)  # does not trigger if there is no time in the file!
             continue
 
         elif line == "" or line.startswith(_ASCII_COMMENT):  # empty or comment line

--- a/turn_by_turn/ptc.py
+++ b/turn_by_turn/ptc.py
@@ -56,7 +56,6 @@ def read_tbt(file_path: Union[str, Path]) -> TbtData:
 
     LOGGER.debug("Reading header from file")
     date, header_length = _read_header(lines)
-    date = datetime.today().replace(tzinfo=tz.tzutc()) if date is None else date  # safeguard
     lines = lines[header_length:]
 
     # parameters

--- a/turn_by_turn/ptc.py
+++ b/turn_by_turn/ptc.py
@@ -56,6 +56,7 @@ def read_tbt(file_path: Union[str, Path]) -> TbtData:
 
     LOGGER.debug("Reading header from file")
     date, header_length = _read_header(lines)
+    date = datetime.today().replace(tzinfo=tz.tzutc()) if date is None else date  # safeguard
     lines = lines[header_length:]
 
     # parameters
@@ -71,7 +72,7 @@ def read_tbt(file_path: Union[str, Path]) -> TbtData:
         )
 
     LOGGER.debug(f"Read Tbt matrices from: '{file_path.absolute()}'")
-    return TbtData(matrices, date, particles, n_turns)
+    return TbtData(matrices=matrices, date=date, bunch_ids=particles, nturns=n_turns)
 
 
 def _read_header(lines: Sequence[str]) -> Tuple[datetime, int]:

--- a/turn_by_turn/structures.py
+++ b/turn_by_turn/structures.py
@@ -38,10 +38,14 @@ class TbtData:
     """
 
     matrices: Sequence[TransverseData]  # each entry corresponds to a bunch
-    date: datetime = datetime.today().replace(tzinfo=tz.tzutc())  # defaults to today, UTC if nothing is given
-    bunch_ids: List[int] = None
+    date: datetime = None  # will default in post_init
+    bunch_ids: List[int] = None  # will default in post_init
     nturns: int = 0
     nbunches: int = field(init=False)
 
     def __post_init__(self):
         self.nbunches = len(self.bunch_ids)
+        if self.date is None:
+            self.date = datetime.today().replace(tzinfo=tz.tzutc())  # to today, UTC if nothing is given
+        if self.bunch_ids is None:
+            self.bunch_ids = []

--- a/turn_by_turn/structures.py
+++ b/turn_by_turn/structures.py
@@ -38,7 +38,7 @@ class TbtData:
     """
 
     matrices: Sequence[TransverseData]  # each entry corresponds to a bunch
-    date: datetime = datetime.today().replace(tzinfo=tz.tzutc())  # defaults to today, UTC
+    date: datetime = datetime.today().replace(tzinfo=tz.tzutc())  # defaults to today, UTC if nothing is given
     bunch_ids: List[int] = None
     nturns: int = 0
     nbunches: int = field(init=False)

--- a/turn_by_turn/utils.py
+++ b/turn_by_turn/utils.py
@@ -122,4 +122,4 @@ def numpy_to_tbts(names: np.ndarray, matrix: np.ndarray) -> TbtData:
             )
         )
         indices.append(index)
-    return TbtData(matrices=matrices, bunch_ids=indices, nturns=nturns)
+    return TbtData(matrices=matrices, date=None, bunch_ids=indices, nturns=nturns)

--- a/turn_by_turn/utils.py
+++ b/turn_by_turn/utils.py
@@ -122,4 +122,4 @@ def numpy_to_tbts(names: np.ndarray, matrix: np.ndarray) -> TbtData:
             )
         )
         indices.append(index)
-    return TbtData(matrices, None, indices, nturns)
+    return TbtData(matrices=matrices, bunch_ids=indices, nturns=nturns)

--- a/turn_by_turn/utils.py
+++ b/turn_by_turn/utils.py
@@ -122,4 +122,4 @@ def numpy_to_tbts(names: np.ndarray, matrix: np.ndarray) -> TbtData:
             )
         )
         indices.append(index)
-    return TbtData(matrices=matrices, date=None, bunch_ids=indices, nturns=nturns)
+    return TbtData(matrices=matrices, bunch_ids=indices, nturns=nturns)


### PR DESCRIPTION
As noticed by Ewen when trying to use the `omc3.tbt_converter` on a `PS` file - which is traditionnally read as `LHC` - the reading works but the writing later on fails with the following error: 
```
AttributeError: 'NoneType' object has no attribute 'timestamp'
```

After investigating, I have found that the default date value safeguard would not trigger in case the file does not have a timestamp line at all, which was the case here. Specifically, in `turn_by_turn.lhc`, the branch (line 120)
```python
        if _ACQ_DATE_PREFIX in line:
            LOGGER.debug("Acquiring date from file")
            date = _parse_date(line)
            continue
```

would not trigger, and the `date` value would stay `None` as initiallized earlier in the function.

This PR adds safeguards in the `date` values in the proper places for the readers to avoid this happening again. 

I have also bumped the version to a patch one, and made `TbtData` objects creation use `kwargs` for clarity for future maintainers.