### PR TITLE
Fix xtrack tests config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ xtrack = [
 test = [
     "pytest>=7.0",
     "pytest-cov>=2.9",
+    "xsuite",  # or it bugs out on prebuilt kernels
     "turn_by_turn[madng]",
     "turn_by_turn[xtrack]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,18 +54,16 @@ madng = [
     "tfs-pandas >= 4.0.0",   # for reading MAD-NG files (Could do everything in memory with just pandas)
 ]
 
-xtrack = [
-    "xtrack >= 0.99.0",      # for xtrack
-    "setuptools >= 65",      # for xtrack
-    "xpart >= 0.23.8",       # for xtrack
+xsuite = [
+    "xsuite >= 0.54.6; sys_platform != 'win32'",
 ]
+
 
 test = [
     "pytest>=7.0",
     "pytest-cov>=2.9",
-    "xsuite",  # or it bugs out on prebuilt kernels
     "turn_by_turn[madng]",
-    "turn_by_turn[xtrack]",
+    "turn_by_turn[xsuite]",
 ]
 
 doc = [
@@ -77,7 +75,7 @@ all = [
     "turn_by_turn[test]",
     "turn_by_turn[doc]",
     "turn_by_turn[madng]",
-    "turn_by_turn[xtrack]",
+    "turn_by_turn[xsuite]",
 ]
 
 [project.urls]

--- a/tests/test_xtrack.py
+++ b/tests/test_xtrack.py
@@ -2,6 +2,8 @@ import sys
 
 import numpy as np
 import pytest
+
+pytest.importorskip("xtrack")  # Skip all tests in this file if xtrack is not installed
 import xtrack as xt
 
 from tests.test_lhc_and_general import compare_tbt

--- a/tests/test_xtrack.py
+++ b/tests/test_xtrack.py
@@ -14,7 +14,6 @@ from turn_by_turn.xtrack.converter import convert_to_tbt as xtrack_convert_to_tb
 from turn_by_turn.xtrack.converter import read_tbt
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="xtrack not supported on Windows")
 def test_convert_xsuite(example_line: xt.Line, example_fake_tbt: TbtData):
     # Build the particles
     particles = example_line.build_particles(x=[1e-3, -1e-3], y=[-1e-3, 1e-3])
@@ -33,7 +32,6 @@ def test_convert_xsuite(example_line: xt.Line, example_fake_tbt: TbtData):
     assert tbt_data.meta["source_datatype"] == "xtrack_particles_monitor"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="xtrack not supported on Windows")
 @pytest.mark.skipif(
     xt.__version__ < "0.99.0", reason="xtrack version does not support multi-element monitor"
 )
@@ -51,7 +49,6 @@ def test_convert_xsuite_multi_element_monitor(example_line: xt.Line, example_fak
     assert tbt_data.meta["source_datatype"] == "xtrack_multi_element_monitor"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="xtrack not supported on Windows")
 def test_read_tbt_raises_not_implemented():
     with pytest.raises(
         NotImplementedError, match="Reading TBT data from xtrack Line files is not implemented"
@@ -65,7 +62,6 @@ def test_convert_to_tbt_invalid_type():
         xtrack_convert_to_tbt("not a line")  # ty:ignore[invalid-argument-type]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="xtrack not supported on Windows")
 def test_convert_to_tbt_no_monitors():
     # Create a line without monitors
     line = xt.Line(elements=[xt.Drift(length=1.0)], element_names=["drift"])


### PR DESCRIPTION
Recent Xsuite changes require `xsuite` for prebuilt kernels use. This has been failing the cron jobs. Simple fix is to include it in the test extras (no the `xtrack` extras, we don't want to force all `xsuite` dependencies on users).