### PR TITLE
Negate horizontal BPM reading for PSB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to **turn_by_turn** will be documented in this file.
 
+### v1.5.0 - 2026-07-23
+
+Now, when reading PSB files, the horizontal position of the BPM is negated to match the model convention, as the PSB runs anticlockwise.
+
+
 ### v1.4.1 - 2026-04-13
 
 Adds an alias for the PSB module, `psbooster`, for compatibility with the beta-beat GUI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to **turn_by_turn** will be documented in this file.
 
 ### v1.5.0 - 2026-07-23
 
-Now, when reading PSB files, the horizontal position of the BPM is negated to match the model convention, as the PSB runs anticlockwise.
+Now, when reading PSB files, the horizontal position of the BPM is inverted to match the model convention, as the PSB runs anticlockwise.
 
 
 ### v1.4.1 - 2026-04-13

--- a/tests/test_psb.py
+++ b/tests/test_psb.py
@@ -64,7 +64,7 @@ def test_read_psb_via_io_dispatch(_psb_file):
 def test_psb_and_lhc_converted_data_match(_psb_file, _lhc_converted_file):
     """PSB data must match the previously converted LHC file values (from Ewen).
 
-    Horizontal is negated by the PSB reader (``psb.X_SIGN``) to convert from the
+    Horizontal sign is inverted by the PSB reader (``psb.X_SIGN``) to convert from the
     BPM hardware convention to the tracking convention. The LHC reader applies no
     such correction, so on the converted copy of the same file the two readers
     must agree in Y and differ by exactly a sign in X.
@@ -87,8 +87,8 @@ def test_psb_and_lhc_converted_data_match(_psb_file, _lhc_converted_file):
     np.testing.assert_allclose(matrix_psb.Y.to_numpy(), matrix_lhc.Y.to_numpy(), rtol=0.0, atol=1e-8)
 
 
-def test_psb_negates_horizontal_against_raw_sdds(monkeypatch, tmp_path):
-    """The reader must negate X and leave Y untouched, exactly."""
+def test_psb_inverts_horizontal_against_raw_sdds(monkeypatch, tmp_path):
+    """The reader must invert the horizontal sign and leave Y untouched, exactly."""
     fake_values = {
         psb.N_BUNCHES: 1,
         psb.N_TURNS: 2,

--- a/tests/test_psb.py
+++ b/tests/test_psb.py
@@ -62,7 +62,13 @@ def test_read_psb_via_io_dispatch(_psb_file):
 
 
 def test_psb_and_lhc_converted_data_match(_psb_file, _lhc_converted_file):
-    """Core regression test: PSB data must match the converted LHC file values."""
+    """PSB data must match the previously converted LHC file values (from Ewen).
+
+    Horizontal is negated by the PSB reader (``psb.X_SIGN``) to convert from the
+    BPM hardware convention to the tracking convention. The LHC reader applies no
+    such correction, so on the converted copy of the same file the two readers
+    must agree in Y and differ by exactly a sign in X.
+    """
     tbt_psb = read_tbt(_psb_file, datatype="psb")
     tbt_lhc = read_tbt(_lhc_converted_file, datatype="lhc")
 
@@ -75,8 +81,29 @@ def test_psb_and_lhc_converted_data_match(_psb_file, _lhc_converted_file):
     assert list(matrix_psb.X.index) == list(matrix_lhc.X.index)
     assert list(matrix_psb.Y.index) == list(matrix_lhc.Y.index)
 
-    np.testing.assert_allclose(matrix_psb.X.to_numpy(), matrix_lhc.X.to_numpy(), rtol=0.0, atol=1e-8)
+    np.testing.assert_allclose(
+        matrix_psb.X.to_numpy(), psb.X_SIGN * matrix_lhc.X.to_numpy(), rtol=0.0, atol=1e-8
+    )
     np.testing.assert_allclose(matrix_psb.Y.to_numpy(), matrix_lhc.Y.to_numpy(), rtol=0.0, atol=1e-8)
+
+
+def test_psb_negates_horizontal_against_raw_sdds(monkeypatch, tmp_path):
+    """The reader must negate X and leave Y untouched, exactly."""
+    fake_values = {
+        psb.N_BUNCHES: 1,
+        psb.N_TURNS: 2,
+        psb.ACQ_STAMP: 1775638241670,
+        psb.BPM_NAMES: np.array(["BPM.TEST"], dtype=object),
+        psb.BUNCH_ID: np.array([0], dtype=int),
+        psb.POSITIONS["X"]: np.array([1.0, -2.0], dtype=float),
+        psb.POSITIONS["Y"]: np.array([3.0, -4.0], dtype=float),
+    }
+    monkeypatch.setattr(psb.sdds, "read", lambda _path: SimpleNamespace(values=fake_values))
+
+    matrix = psb.read_tbt(tmp_path / "dummy.sdds").matrices[0]
+
+    np.testing.assert_allclose(matrix.X.to_numpy(), np.array([[-1.0, 2.0]]))
+    np.testing.assert_allclose(matrix.Y.to_numpy(), np.array([[3.0, -4.0]]))
 
 
 def test_hor_bunch_id_fallback_and_truncation(monkeypatch, tmp_path):

--- a/turn_by_turn/__init__.py
+++ b/turn_by_turn/__init__.py
@@ -8,7 +8,7 @@ __description__ = (
     "Read and write turn-by-turn measurement files from different particle accelerator formats."
 )
 __url__ = "https://github.com/pylhc/turn_by_turn"
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/turn_by_turn/psb.py
+++ b/turn_by_turn/psb.py
@@ -44,7 +44,7 @@ POSITIONS: dict[str, str] = {
 #
 #     x_bpm = -x_tracking
 #
-# The raw SDDS payload is in the hardware convention. We negate it here, at the
+# The raw SDDS payload is in the hardware convention. We invert it here, at the
 # single point where PSB files enter the codebase, so that every consumer -- omc3
 # included -- works in the standard tracking frame. Do not apply this correction
 # a second time downstream.
@@ -60,7 +60,7 @@ def read_tbt(file_path: str | Path) -> TbtData:
     Args:
         file_path (Union[str, Path]): path to the turn-by-turn measurement file.
 
-    The horizontal plane is negated on read to convert from the PSB BPM hardware
+    The horizontal plane is inverted on read to convert from the PSB BPM hardware
     convention to the MAD-X / tracking convention -- see ``X_SIGN`` above.
 
     Returns:

--- a/turn_by_turn/psb.py
+++ b/turn_by_turn/psb.py
@@ -39,6 +39,19 @@ POSITIONS: dict[str, str] = {
     "Y": "verPositionsConcentratedAndSorted",
 }
 
+# The PSB beam travels counter-clockwise, so the BPM pickups measure horizontal
+# position with the opposite sign to the MAD-X / tracking coordinate system:
+#
+#     x_bpm = -x_tracking
+#
+# The raw SDDS payload is in the hardware convention. We negate it here, at the
+# single point where PSB files enter the codebase, so that every consumer -- omc3
+# included -- works in the standard tracking frame. Do not apply this correction
+# a second time downstream.
+#
+# Vertical is unaffected. Units are left as-is (millimetres, as stored).
+X_SIGN: float = -1.0
+
 
 def read_tbt(file_path: str | Path) -> TbtData:
     """
@@ -47,8 +60,11 @@ def read_tbt(file_path: str | Path) -> TbtData:
     Args:
         file_path (Union[str, Path]): path to the turn-by-turn measurement file.
 
+    The horizontal plane is negated on read to convert from the PSB BPM hardware
+    convention to the MAD-X / tracking convention -- see ``X_SIGN`` above.
+
     Returns:
-        A ``TbtData`` object with the loaded data.
+        A ``TbtData`` object with the loaded data, horizontal sign corrected.
     """
     file_path = Path(file_path)
     LOGGER.debug(f"Reading PSB file at path: '{file_path.absolute()}'")
@@ -74,7 +90,7 @@ def read_tbt(file_path: str | Path) -> TbtData:
 
     matrices = [
         TransverseData(
-            X=pd.DataFrame(index=bpm_names, data=data["X"][:, idx, :], dtype=float),
+            X=pd.DataFrame(index=bpm_names, data=X_SIGN * data["X"][:, idx, :], dtype=float),
             Y=pd.DataFrame(index=bpm_names, data=data["Y"][:, idx, :], dtype=float),
         )
         for idx in range(nbunches)


### PR DESCRIPTION
Negate the horizontal reading of the BPMs. This is because of the anticlockwise nature of the PSB ring. Beam 2 technically is affected by this, but the BPMs pick up in beam 2 frame, not beam 4.